### PR TITLE
fix documents

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install --cask fastlane`
 
 # Available Actions
 ### release

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew install --cask fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ### release


### PR DESCRIPTION
Fix error about latest Homebrew.
`brew cask install fastlane` is in `fastlane/README.md`, but this doesn't work now because of update of Homebrew.
 This is not a bug of this app, but `fastlane/README.md` needs to be fixed.

homebrew blog: [2.6.0 — Homebrew](https://brew.sh/2020/12/01/homebrew-2.6.0/)

> All brew cask commands have been deprecated in favour of brew commands (with --cask) when necessary